### PR TITLE
Fix for Rosey Generate command

### DIFF
--- a/lib/rosey.js
+++ b/lib/rosey.js
@@ -9,7 +9,7 @@ module.exports = class Rosey {
 		const sourcePath = Rosey.getSourcePath();
 		const sourceLocalePath = path.join(Rosey.getSourceLocalPath(), buildConfig.locale_source);
 		const destinationPath = Rosey.getDestinationPath();
-		const sourceDestinationPath = `${destinationPath}cms-current-locale.json`;
+		const sourceDestinationPath = path.join(destinationPath, 'cms-current-locale.json');
 
 		const generateCommand = `rosey generate --source ${sourcePath} --tag ${buildConfig.tag}  --version ${buildConfig.version} --locale-dest ${sourceDestinationPath}`;
 		const buildCommand = `rosey build --locale-source ${sourceLocalePath} --source ${sourcePath} --tag ${buildConfig.tag} --default-language ${buildConfig.default_language} --version ${buildConfig.version} --dest ${destinationPath} --yes --overwrite`;


### PR DESCRIPTION
The path where the generated tags for translation is being saved is missing a `/`  to properly save on the folder that is exported by the build.

`$ rosey generate --source ****-****.cloudvent.net/compiled --tag data-rosey  --version 2 --locale-dest ****-****.cloudvent.net/i18ncms-current-locale.json`

Note the `i18ncms-current-locale.json` should be `i18n/cms-current-locale.json`